### PR TITLE
address some input and output issues with llama3 test

### DIFF
--- a/alt_e2eshark/onnx_tests/models/llama.py
+++ b/alt_e2eshark/onnx_tests/models/llama.py
@@ -49,49 +49,17 @@ class LlamaModelInfo(OnnxModelInfo):
         # we decided to set `export_params=False` and `do_constant_folding=False`
         # in the torch.onnx.export of this model. This will convert initializers
         # to inputs in the onnx model, which we need to convert back to util.global
-        # ops in the importer. Therefore, we specify that the model has 7 actual inputs
+        # ops in the importer. Therefore, we specify that the model has 3 actual inputs
         # for the `externalize_params` route in the iree-import-onnx tool. `large-model`
         # is additionally specified since we don't need to update the opset version
         # or check the model size.
-        # The compile flags for rocm match what we are using for similar models.
-        # Lastly, we add some runtime options specifically to point to the irpa files
-        # generated for this test.
-        if self.dynamic:
-            rocm_compile_flags = tuple()
-        else:
-            rocm_compile_flags = (
-                "iree-execution-model=async-external",
-                "iree-global-opt-propagate-transposes=1",
-                "iree-opt-const-eval=0",
-                "iree-opt-outer-dim-concat=1",
-                "iree-opt-aggressively-propagate-transposes=1",
-                "iree-dispatch-creation-enable-aggressive-fusion",
-                "iree-codegen-llvmgpu-use-vector-distribution=1",
-                "iree-llvmgpu-enable-prefetch=1",
-                "iree-codegen-gpu-native-math-precision=1",
-                "iree-hip-legacy-sync=0",
-                "iree-opt-data-tiling=0",
-                "iree-vm-target-truncate-unsupported-floats",
-                "iree-hal-force-indirect-command-buffers",
-                "iree-preprocessing-pass-pipeline="
-                "'builtin.module(util.func(iree-global-opt-raise-special-ops, iree-flow-canonicalize), "
-                "iree-preprocessing-transpose-convolution-pipeline, "
-                "iree-preprocessing-pad-to-intrinsics, "
-                "util.func(iree-preprocessing-generalize-linalg-matmul-experimental))'",
-                "iree-dispatch-creation-enable-fuse-horizontal-contractions=1",
-            )
+        # TODO: figure out which rocm flags to use
         self.extra_options = ExtraOptions(
             import_model_options=ImporterOptions(
-                externalize_inputs_threshold=7,
+                externalize_inputs_threshold=3,
                 num_elements_threshold=32,
                 externalize_params=True,
                 large_model=True,
-            ),
-            compilation_options=CompilerOptions(
-                backend_specific_flags={
-                    "rocm": rocm_compile_flags,
-                    "hip": rocm_compile_flags,
-                }
             ),
             compiled_inference_options=RuntimeOptions(
                 common_extra_args=(
@@ -104,15 +72,14 @@ class LlamaModelInfo(OnnxModelInfo):
     def construct_inputs(self):
         torch.manual_seed(0)
         shapes, dtypes = self.get_signature()
+        # TODO: Allow passing in position_ids, attn_mask, and past_key_value pairs.
+        # Currently, a 0 tensor needs to be passed as the third input for the onnx model.
+        # This is possibly due to a lack of position_ids provided for the export. 
         return TestTensors(
             (
                 torch.ones(*(shapes[0]), dtype=dtypes[0]),
                 torch.ones(*(shapes[1]), dtype=dtypes[1]),
-                torch.ones(*(shapes[2]), dtype=dtypes[2]),
-                torch.randn(*(shapes[3]), dtype=dtypes[3]),
-                torch.randn(*(shapes[4]), dtype=dtypes[4]),
-                torch.randn(*(shapes[5]), dtype=dtypes[5]),
-                torch.randn(*(shapes[6]), dtype=dtypes[6]),
+                torch.tensor(0).to(dtype=dtypes[2])
             )
         )
 
@@ -185,9 +152,19 @@ class LlamaModelInfo(OnnxModelInfo):
             output = model.forward(
                 input_ids=data[0],
                 attention_mask=data[1],
-                return_dict=True,
+                return_dict=False,
             )
-            return TestTensors((output.logits,))
+            # outputs = (logits, (k0, v0), ..., (k63, v63))
+            # the following flattens the output tuples to a list
+            output_list = []
+            def recursively_unpack(item):
+                if isinstance(item, tuple):
+                    for t in item:
+                        recursively_unpack(t)
+                if isinstance(item, torch.Tensor):
+                    output_list.append(item)
+            recursively_unpack(output)
+            return TestTensors(tuple(output_list))
 
     def get_signature(self, *, from_inputs=True, leave_dynamic=False):
         def d(dim: Union[str, int]) -> Union[str, int]:
@@ -202,24 +179,20 @@ class LlamaModelInfo(OnnxModelInfo):
             shapes = [
                 [B, L],
                 [B, L],
-                [1],
-                [128256, 4096],
-                [4096, 4096],
-                [1024, 4096],
-                [1024, 4096],
+                [],
             ]
             dtypes = [
                 torch.int64,
                 torch.int64,
                 torch.int64,
-                torch.float32,
-                torch.float32,
-                torch.float32,
-                torch.float32,
             ]
         else:
+            # output:
             shapes = [[B, L, 128256]]
             dtypes = [torch.float32]
+            for _ in range(0,64):
+                shapes.append([B,8,L,128])
+                dtypes.append(torch.float32)
 
         return shapes, dtypes
 


### PR DESCRIPTION
Unfortunately, it took me a bit of time to debug what was going wrong. With these changes, the test should pass on CPU (need to test GPU). 

1. There should only be two inputs (not 7 like flux). That being said, the lack of position_ids seems to generate an artificial third input for the onnx model which looks like it gets used as a negative padding for the output (it will slice across the sequence length dim from the back, e.g. passing [2] for the third input would return a logits tensor of shape [1, 512-2, 128256]). This should be 0 to match the pytorch output. 
2. I've included the output past-key-value pairs in the model info `forward` method, since the onnx model still has these outputs after tracing.
3. I've removed the rocm compile flags, since I don't know what they should be yet.
4. Added some comments. 